### PR TITLE
fix: use https

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -37,7 +37,7 @@ class Client extends EventEmitter {
       typeof options.maxUsePercent !== 'undefined'
         ? options.maxUsePercent
         : MAX_USE_PERCENT_DEFAULT
-    this.baseUrl = options.baseUrl || 'http://api.hubapi.com'
+    this.baseUrl = options.baseUrl || 'https://api.hubapi.com'
     this.apiTimeout = options.timeout || API_TIMEOUT
     this.apiCalls = 0
     this.on('apiCall', params => {


### PR DESCRIPTION
Hubspot seems to be requiring HTTPS now.
